### PR TITLE
Add expandable tooltips to skills section

### DIFF
--- a/src/components/home/SkillsSection.tsx
+++ b/src/components/home/SkillsSection.tsx
@@ -7,7 +7,7 @@
 
 'use client';
 
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useState, useEffect } from 'react';
 
 /* ###########################################################
    ###   1. Skills Data                                     ###
@@ -16,34 +16,35 @@ import { useRef, useCallback } from 'react';
 interface Skill {
   name: string;
   category: 'ml' | 'web' | 'tools';
+  description: string;
 }
 
 const skills: Skill[] = [
   // ML & AI
-  { name: 'Python', category: 'ml' },
-  { name: 'PyTorch', category: 'ml' },
-  { name: 'TensorFlow', category: 'ml' },
-  { name: 'scikit-learn', category: 'ml' },
-  { name: 'pandas', category: 'ml' },
-  { name: 'NumPy', category: 'ml' },
-  { name: 'Deep Learning', category: 'ml' },
-  { name: 'Reinforcement Learning', category: 'ml' },
+  { name: 'Python', category: 'ml', description: 'Primary language for data science, ML pipelines, and automation scripts.' },
+  { name: 'PyTorch', category: 'ml', description: 'Building and training neural networks, especially for research and experimentation.' },
+  { name: 'TensorFlow', category: 'ml', description: 'Production ML models and deployment with TensorFlow Serving.' },
+  { name: 'scikit-learn', category: 'ml', description: 'Classical ML algorithms, preprocessing, and model evaluation.' },
+  { name: 'pandas', category: 'ml', description: 'Data manipulation, cleaning, and exploratory analysis.' },
+  { name: 'NumPy', category: 'ml', description: 'Numerical computing and array operations for ML workflows.' },
+  { name: 'Deep Learning', category: 'ml', description: 'CNNs, transformers, and architectures for vision and NLP tasks.' },
+  { name: 'Reinforcement Learning', category: 'ml', description: 'Training agents with reward-based learning for decision-making problems.' },
   // Web Development
-  { name: 'TypeScript', category: 'web' },
-  { name: 'React', category: 'web' },
-  { name: 'Next.js', category: 'web' },
-  { name: 'Node.js', category: 'web' },
-  { name: 'Tailwind', category: 'web' },
-  { name: 'Supabase', category: 'web' },
-  { name: 'PostgreSQL', category: 'web' },
+  { name: 'TypeScript', category: 'web', description: 'Type-safe JavaScript for scalable, maintainable codebases.' },
+  { name: 'React', category: 'web', description: 'Building interactive UIs with component-based architecture.' },
+  { name: 'Next.js', category: 'web', description: 'Full-stack React apps with SSR, routing, and API routes.' },
+  { name: 'Node.js', category: 'web', description: 'Server-side JavaScript for APIs and backend services.' },
+  { name: 'Tailwind', category: 'web', description: 'Utility-first CSS for rapid, consistent styling.' },
+  { name: 'Supabase', category: 'web', description: 'Backend-as-a-service with auth, database, and realtime features.' },
+  { name: 'PostgreSQL', category: 'web', description: 'Relational database for complex queries and data integrity.' },
   // Tools
-  { name: 'Git', category: 'tools' },
-  { name: 'Docker', category: 'tools' },
-  { name: 'GitHub Actions', category: 'tools' },
-  { name: 'Linux', category: 'tools' },
-  { name: 'CI/CD', category: 'tools' },
-  { name: 'VS Code', category: 'tools' },
-  { name: 'Jupyter', category: 'tools' },
+  { name: 'Git', category: 'tools', description: 'Version control for collaboration and code history.' },
+  { name: 'Docker', category: 'tools', description: 'Containerizing applications for consistent deployment environments.' },
+  { name: 'GitHub Actions', category: 'tools', description: 'Automated CI/CD workflows for testing and deployment.' },
+  { name: 'Linux', category: 'tools', description: 'Server administration, shell scripting, and development environment.' },
+  { name: 'CI/CD', category: 'tools', description: 'Automated pipelines for continuous integration and delivery.' },
+  { name: 'VS Code', category: 'tools', description: 'Primary IDE with extensions for all development workflows.' },
+  { name: 'Jupyter', category: 'tools', description: 'Interactive notebooks for data exploration and ML experiments.' },
 ];
 
 const categoryColors = {
@@ -71,11 +72,138 @@ const categoryColors = {
 };
 
 /* ###########################################################
-   ###   2. Component                                       ###
+   ###   2. Tooltip Component                               ###
+   ########################################################### */
+
+interface TooltipProps {
+  skill: Skill;
+  colors: typeof categoryColors.ml;
+  position: { x: number; y: number };
+  visible: boolean;
+}
+
+function SkillTooltip({ skill, colors, position, visible }: TooltipProps) {
+  return (
+    <div
+      className="fixed z-50 pointer-events-none"
+      style={{
+        left: position.x,
+        top: position.y,
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(-4px)',
+        transition: 'opacity 0.2s ease, transform 0.2s ease',
+      }}
+    >
+      <div
+        className="px-3 py-2 rounded-lg text-xs max-w-[220px] shadow-lg"
+        style={{
+          background: 'var(--bg)',
+          border: `1px solid ${colors.border}`,
+          color: 'var(--ink-secondary)',
+        }}
+      >
+        <div className="font-medium mb-1" style={{ color: colors.text }}>
+          {skill.name}
+        </div>
+        <div style={{ lineHeight: 1.4 }}>{skill.description}</div>
+        {/* Arrow */}
+        <div
+          className="absolute -top-1.5 left-4 w-3 h-3 rotate-45"
+          style={{
+            background: 'var(--bg)',
+            borderLeft: `1px solid ${colors.border}`,
+            borderTop: `1px solid ${colors.border}`,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ###########################################################
+   ###   3. Main Component                                  ###
    ########################################################### */
 
 export default function SkillsSection() {
   const cloudRef = useRef<HTMLDivElement>(null);
+  const [activeSkill, setActiveSkill] = useState<Skill | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+  const [isVisible, setIsVisible] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Detect mobile on mount
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.matchMedia('(hover: none)').matches);
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  // Close tooltip when clicking outside on mobile
+  useEffect(() => {
+    if (!isMobile || !activeSkill) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('.skill-tag')) {
+        setIsVisible(false);
+        setTimeout(() => setActiveSkill(null), 200);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, [isMobile, activeSkill]);
+
+  const showTooltip = useCallback((skill: Skill, element: HTMLElement) => {
+    const rect = element.getBoundingClientRect();
+    const tooltipX = rect.left;
+    const tooltipY = rect.bottom + 8;
+
+    setActiveSkill(skill);
+    setTooltipPosition({ x: tooltipX, y: tooltipY });
+    // Small delay to trigger CSS transition
+    requestAnimationFrame(() => setIsVisible(true));
+  }, []);
+
+  const hideTooltip = useCallback(() => {
+    setIsVisible(false);
+    setTimeout(() => setActiveSkill(null), 200);
+  }, []);
+
+  const handleTagInteraction = useCallback(
+    (skill: Skill, element: HTMLElement, e: React.MouseEvent) => {
+      if (isMobile) {
+        e.stopPropagation();
+        if (activeSkill?.name === skill.name) {
+          hideTooltip();
+        } else {
+          showTooltip(skill, element);
+        }
+      }
+    },
+    [isMobile, activeSkill, showTooltip, hideTooltip]
+  );
+
+  const handleTagMouseEnter = useCallback(
+    (skill: Skill, element: HTMLElement) => {
+      if (isMobile) return;
+      // Small delay before showing tooltip to avoid flicker
+      hoverTimeoutRef.current = setTimeout(() => {
+        showTooltip(skill, element);
+      }, 150);
+    },
+    [isMobile, showTooltip]
+  );
+
+  const handleTagMouseLeave = useCallback(() => {
+    if (isMobile) return;
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+    }
+    hideTooltip();
+  }, [isMobile, hideTooltip]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     if (!cloudRef.current) return;
@@ -133,7 +261,7 @@ export default function SkillsSection() {
             return (
               <span
                 key={skill.name}
-                className="skill-tag px-4 py-2 text-sm rounded-full cursor-default select-none"
+                className="skill-tag px-4 py-2 text-sm rounded-full cursor-pointer select-none"
                 data-glow={colors.glow}
                 style={{
                   background: colors.bg,
@@ -141,6 +269,9 @@ export default function SkillsSection() {
                   color: colors.text,
                   transition: 'transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
                 }}
+                onClick={(e) => handleTagInteraction(skill, e.currentTarget, e)}
+                onMouseEnter={(e) => handleTagMouseEnter(skill, e.currentTarget)}
+                onMouseLeave={handleTagMouseLeave}
               >
                 {skill.name}
               </span>
@@ -164,6 +295,16 @@ export default function SkillsSection() {
           </div>
         </div>
       </div>
+
+      {/* Tooltip */}
+      {activeSkill && (
+        <SkillTooltip
+          skill={activeSkill}
+          colors={categoryColors[activeSkill.category]}
+          position={tooltipPosition}
+          visible={isVisible}
+        />
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Add descriptions for all 23 skills explaining their use cases
- Implement hover tooltips on desktop with 150ms delay
- Add tap-to-toggle tooltips on mobile devices
- Smooth fade and slide animations with color-matched borders

## Test plan
- [ ] Hover over skills on desktop - tooltip appears below with description
- [ ] Move away quickly - tooltip does not flicker
- [ ] Tap skills on mobile - tooltip toggles on/off
- [ ] Tap outside tooltip on mobile - closes it
- [ ] Verify magnetic float effect still works alongside tooltips