### PR TITLE
Fix GitHub Actions workflow warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,11 @@ jobs:
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/
           retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,15 +28,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Update CodeQL action from v3 to v4 (addressing deprecation warning)
- Fix Playwright report upload to only run on failure with if-no-files-found: ignore
- Also upload test-results/ directory when tests fail for better debugging

## Changes
- .github/workflows/codeql.yml: Updated all CodeQL actions from @v3 to @v4
- .github/workflows/ci.yml: Fixed artifact upload step to not warn when report does not exist