### PR TITLE
Fix lanyard rope rendering behind hero text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,7 @@ export default async function HomePage() {
       {/* =====================================================
           HERO SECTION - Main intro with animated lanyard
           ===================================================== */}
-      <section className="relative min-h-[90vh] flex items-center pt-20">
+      <section className="relative z-0 min-h-[90vh] flex items-center pt-20">
         {/* Background layer - separate so lanyard can overlay */}
         <div
           className="absolute inset-0 z-0"


### PR DESCRIPTION
## Summary
- Add explicit `z-0` stacking context on hero section so the fixed lanyard container (`z-40`) renders the rope above hero text content

## Test plan
- [ ] Verify lanyard rope renders on top of hero text on desktop
- [ ] Verify badge card still renders above text
- [ ] Verify no visual regressions on other sections