### PR TITLE
feat(RenovaeLabs): epic upgrade — holographic seal, dramatic reveals

### DIFF
--- a/public/RenovaeLabs/app.js
+++ b/public/RenovaeLabs/app.js
@@ -78,12 +78,15 @@
       boot.classList.add('is-done');
       requestAnimationFrame(() => boot.remove());
     } else {
-      // Total boot length ~1.55s
+      // Why: was 1550ms which felt like a hold. Boot is now glassy (CSS),
+      // so the molecular network is visible behind it from frame one.
+      // Cut to 1100ms — log still reads, but no perceived "delay" before
+      // the hero reveals itself.
       setTimeout(() => {
         boot.classList.add('is-done');
         sessionStorage.setItem('rnv_seen', '1');
-        setTimeout(() => boot.remove(), 600);
-      }, 1550);
+        setTimeout(() => boot.remove(), 500);
+      }, 1100);
     }
   }
 
@@ -159,7 +162,61 @@
   }
 
   // ─────────────────────────────────────────────────────────────────
-  // 5. Molecular network — pseudo-3D, depth-sorted, parallax
+  // 5. Holographic foil — mouse / device-tilt tracking
+  //    Why: ties the wordmark's foil shimmer + the COA seal's highlight
+  //    to the cursor so it reads like a real foil under a real light
+  //    source, not a static gradient.
+  // ─────────────────────────────────────────────────────────────────
+  const root = document.documentElement;
+  const seal = document.querySelector('.holo-seal');
+
+  let foilT;
+  function onFoilPointer(e){
+    const x = (e.clientX / window.innerWidth) * 100;
+    const y = (e.clientY / window.innerHeight) * 100;
+    root.style.setProperty('--foil-x', x + '%');
+    root.style.setProperty('--foil-y', y + '%');
+
+    if (seal){
+      const r = seal.getBoundingClientRect();
+      const sx = ((e.clientX - r.left) / r.width)  * 100;
+      const sy = ((e.clientY - r.top)  / r.height) * 100;
+      seal.style.setProperty('--hx', Math.max(-30, Math.min(130, sx)) + '%');
+      seal.style.setProperty('--hy', Math.max(-30, Math.min(130, sy)) + '%');
+    }
+  }
+  // rAF-throttle
+  let foilRaf = 0, lastFoilEvent = null;
+  window.addEventListener('mousemove', (e) => {
+    lastFoilEvent = e;
+    if (!foilRaf) foilRaf = requestAnimationFrame(() => {
+      foilRaf = 0;
+      if (lastFoilEvent) onFoilPointer(lastFoilEvent);
+    });
+  }, { passive:true });
+
+  // Device orientation on mobile — gyroscope-driven foil shimmer.
+  // iOS requires explicit permission; we attempt without prompting and
+  // fall back gracefully if blocked. Why: most QR scans happen on phone,
+  // so the foil should shift as the user tilts their device.
+  if ('DeviceOrientationEvent' in window){
+    const handler = (e) => {
+      // gamma -90..90 = left-right tilt
+      // beta  -180..180 = front-back tilt
+      const gx = ((e.gamma + 45) / 90) * 100;
+      const gy = ((e.beta  + 30) / 90) * 100;
+      root.style.setProperty('--foil-x', Math.max(0, Math.min(100, gx)) + '%');
+      root.style.setProperty('--foil-y', Math.max(0, Math.min(100, gy)) + '%');
+      if (seal){
+        seal.style.setProperty('--hx', Math.max(0, Math.min(100, gx)) + '%');
+        seal.style.setProperty('--hy', Math.max(0, Math.min(100, gy)) + '%');
+      }
+    };
+    window.addEventListener('deviceorientation', handler, { passive:true });
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // 6. Molecular network — pseudo-3D, depth-sorted, parallax
   //    Why: matches packaging artwork and gives the hero genuine theatre
   // ─────────────────────────────────────────────────────────────────
   if (reducedMotion) return;
@@ -208,12 +265,17 @@
       vz: rand(-.05,.05),
       r: rand(0.7, 1.8),
       bright: Math.random() > 0.78,    // ~22% are highlight nodes
-      hub: i === 0                      // central hub node — slightly larger
+      hub: i === 0                      // anchor hub — see offset below
     }));
     if (nodes[0]){
-      nodes[0].x = 0; nodes[0].y = 0; nodes[0].z = 0;
+      // Why: previously parked at (0,0,0) which projects dead-centre and
+      // washed out the wordmark/lede. Tuck hub into the lower-left quadrant
+      // — still a focal point for the network, never behind the copy.
+      nodes[0].x = -halfW * 0.55;
+      nodes[0].y =  halfH * 0.42;
+      nodes[0].z = -60;
       nodes[0].vx = nodes[0].vy = nodes[0].vz = 0;
-      nodes[0].r = 2.6;
+      nodes[0].r = 2.2;
       nodes[0].bright = true;
       nodes[0].hub = true;
     }
@@ -232,7 +294,12 @@
     let y = n.y * cx - z * sx;
     z = n.y * sx + z * cx;
 
-    const persp = FOV / (FOV + z + 280);  // +280 puts the cluster slightly back
+    // Why: clamp the perspective denominator. On wide viewports halfW gets
+    // big, and a node rotating behind the camera could push (FOV+z+280)
+    // into negative territory — that flips persp negative, makes r negative,
+    // and ctx.arc throws IndexSizeError. Clamp keeps it well-defined.
+    const denom = Math.max(60, FOV + z + 280);
+    const persp = FOV / denom;
     return {
       x: W*0.5 + x * persp,
       y: H*0.5 + y * persp,
@@ -307,10 +374,11 @@
       const alpha = 0.45 + p.s * 0.55;
 
       if (p.bright || p.hub){
-        // Halo glow
-        const haloR = r * (p.hub ? 16 : 6);
+        // Halo glow — hub is dimmer + smaller now (was 0.55 / 16x); enough
+        // to anchor the field without washing out the wordmark or lede.
+        const haloR = r * (p.hub ? 9 : 5);
         const grad = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, haloR);
-        const haloIntensity = (p.hub ? 0.55 : 0.25) * p.s;
+        const haloIntensity = (p.hub ? 0.32 : 0.22) * p.s;
         grad.addColorStop(0, `rgba(207,214,238,${haloIntensity})`);
         grad.addColorStop(1, 'rgba(207,214,238,0)');
         ctx.fillStyle = grad;

--- a/public/RenovaeLabs/index.html
+++ b/public/RenovaeLabs/index.html
@@ -147,9 +147,38 @@
         <div class="coa-card__title">
           <span class="coa-card__title__name">Certificate of Authenticity</span>
           <span class="coa-card__title__sub">Renovae Labs · Internal Manufacturing Record</span>
+          <div class="coa-card__seal" aria-hidden="true">
+            <span class="coa-card__seal__dot"></span>VERIFIED
+          </div>
         </div>
-        <div class="coa-card__seal" aria-hidden="true">
-          <span class="coa-card__seal__dot"></span>VERIFIED
+
+        <!-- Holographic auth seal — passport-stamp style foil disc.
+             Curved "AUTHENTIC · RENOVAE LABS · UK" text follows the rim. -->
+        <div class="holo-seal" aria-hidden="true">
+          <div class="holo-seal__core">
+            <svg class="holo-seal__svg" viewBox="0 0 60 60">
+              <line x1="30" y1="30" x2="14" y2="22"/>
+              <line x1="30" y1="30" x2="46" y2="38"/>
+              <line x1="30" y1="30" x2="42" y2="14"/>
+              <line x1="30" y1="30" x2="18" y2="44"/>
+              <circle cx="14" cy="22" r="2"/>
+              <circle cx="46" cy="38" r="2"/>
+              <circle cx="42" cy="14" r="1.4"/>
+              <circle cx="18" cy="44" r="1.4"/>
+              <circle cx="30" cy="30" r="2.6" fill="#0f1226"/>
+            </svg>
+          </div>
+          <svg class="holo-seal__rim" viewBox="0 0 100 100"
+               style="position:absolute;inset:0;width:100%;height:100%;">
+            <defs>
+              <path id="rimPath" d="M 50,50 m -38,0 a 38,38 0 1,1 76,0 a 38,38 0 1,1 -76,0"/>
+            </defs>
+            <text>
+              <textPath href="#rimPath" startOffset="0">
+                · AUTHENTIC · RENOVAE LABS · UK · CERTIFIED ·
+              </textPath>
+            </text>
+          </svg>
         </div>
       </header>
 

--- a/public/RenovaeLabs/styles.css
+++ b/public/RenovaeLabs/styles.css
@@ -133,30 +133,49 @@ a{ color:inherit; text-decoration:none; }
 }
 .lead--light{ color:var(--sky); }
 
-/* Reveal-on-scroll */
+/* Reveal-on-scroll
+   Why: was a modest 28px+0.9s slide. Now: bigger travel, scale-up from .96,
+   blur unfocus→focus, and longer dwell (1.15s). Reads cinematic, not jumpy. */
 .reveal{
   opacity:0;
-  transform:translateY(28px);
-  transition:opacity .9s cubic-bezier(.2,.7,.2,1), transform .9s cubic-bezier(.2,.7,.2,1);
-  will-change:opacity, transform;
+  transform:translateY(56px) scale(.96);
+  filter:blur(8px);
+  transition:
+    opacity 1.15s cubic-bezier(.2,.7,.2,1),
+    transform 1.15s cubic-bezier(.2,.7,.2,1),
+    filter 1.15s cubic-bezier(.2,.7,.2,1);
+  will-change:opacity, transform, filter;
 }
-.reveal.is-in{ opacity:1; transform:none; }
+.reveal.is-in{
+  opacity:1;
+  transform:none;
+  filter:blur(0);
+}
 
 /* ═══════════════════════════════════════════════════════════════════
    Boot sequence — full-screen verification overlay
 ═══════════════════════════════════════════════════════════════════ */
 .boot{
   position:fixed; inset:0; z-index:100;
-  background:radial-gradient(120% 80% at 30% 20%, #14193a 0%, #06081a 70%);
+  /* Why: glassy + blurred — molecular network behind it animates from
+     frame one, so by the time the boot fades there's no "dead" beat
+     where the hero feels static. */
+  background:linear-gradient(180deg, rgba(13,18,49,.78) 0%, rgba(6,8,26,.82) 100%);
+  backdrop-filter:blur(14px) saturate(1.1);
+  -webkit-backdrop-filter:blur(14px) saturate(1.1);
   color:#dde3f5;
   display:flex; flex-direction:column; align-items:center; justify-content:center;
-  gap:36px;
+  gap:32px;
   padding:24px;
   font-family:var(--f-mono);
   pointer-events:none;
-  transition:opacity .55s ease, visibility .55s;
+  transition:opacity .5s ease, visibility .5s, backdrop-filter .5s ease;
 }
-.boot.is-done{ opacity:0; visibility:hidden; }
+.boot.is-done{
+  opacity:0; visibility:hidden;
+  backdrop-filter:blur(0) saturate(1);
+  -webkit-backdrop-filter:blur(0) saturate(1);
+}
 
 .boot__monogram{
   opacity:0;
@@ -185,10 +204,11 @@ a{ color:inherit; text-decoration:none; }
   transform:translateX(-6px);
   animation: bootLog 380ms cubic-bezier(.2,.7,.2,1) forwards;
 }
-.boot__log li:nth-child(1){ animation-delay:300ms; }
-.boot__log li:nth-child(2){ animation-delay:560ms; }
-.boot__log li:nth-child(3){ animation-delay:820ms; }
-.boot__log li:nth-child(4){ animation-delay:1080ms; }
+/* Why: tightened from 300/560/820/1080 to fit the new 1100ms boot window */
+.boot__log li:nth-child(1){ animation-delay:180ms; }
+.boot__log li:nth-child(2){ animation-delay:340ms; }
+.boot__log li:nth-child(3){ animation-delay:500ms; }
+.boot__log li:nth-child(4){ animation-delay:660ms; }
 @keyframes bootLog{ to{ opacity:1; transform:none; } }
 .boot__prompt{
   display:inline-block;
@@ -220,7 +240,7 @@ a{ color:inherit; text-decoration:none; }
   text-align:center;
   margin-right:10px;
   box-shadow:0 0 0 0 rgba(31,142,108,.5);
-  animation: bootPulse 1.2s ease-out 1080ms 1;
+  animation: bootPulse 1.0s ease-out 660ms 1;
 }
 @keyframes bootPulse{
   0%   { box-shadow:0 0 0 0 rgba(31,142,108,.55); }
@@ -316,8 +336,8 @@ a{ color:inherit; text-decoration:none; }
   letter-spacing:.4em;
   text-transform:uppercase;
   color:var(--periwinkle);
-  opacity:0; transform:translateY(8px);
-  animation: heroIn .9s cubic-bezier(.2,.7,.2,1) 100ms forwards;
+  opacity:0; transform:translateY(20px); filter:blur(6px);
+  animation: heroIn 1.1s cubic-bezier(.2,.7,.2,1) 100ms forwards;
 }
 .hero__eyebrow__line{
   height:1px; width:30px;
@@ -327,8 +347,8 @@ a{ color:inherit; text-decoration:none; }
 .wordmark{
   margin:0;
   display:flex; flex-direction:column; align-items:center; gap:10px;
-  opacity:0; transform:translateY(14px);
-  animation: heroIn 1s cubic-bezier(.2,.7,.2,1) 220ms forwards;
+  opacity:0; transform:translateY(48px) scale(.94); filter:blur(14px);
+  animation: heroIn 1.4s cubic-bezier(.2,.7,.2,1) 220ms forwards;
 }
 .wordmark__word{
   font-family:var(--f-display);
@@ -337,10 +357,30 @@ a{ color:inherit; text-decoration:none; }
   line-height:.95;
   letter-spacing:.18em;
   text-indent:.18em;
-  background:linear-gradient(180deg, #ffffff 0%, #c5cdec 70%, #8e98c4 100%);
+  /* Holographic foil — multi-stop linear gradient with outsized
+     background-size; CSS animation drifts the position, JS layers on
+     mouse-tracking via --foil-x/y custom properties. */
+  background:
+    linear-gradient(115deg,
+      #c5cdec  0%,
+      #ffffff 14%,
+      #d9e0f5 28%,
+      #ffffff 42%,
+      #b5c5e8 56%,
+      #ffffff 70%,
+      #cfd6ee 84%,
+      #ffffff 100%);
+  background-size: 240% 240%;
+  background-position: var(--foil-x, 30%) var(--foil-y, 30%);
   -webkit-background-clip:text; background-clip:text;
   color:transparent;
-  text-shadow:0 1px 0 rgba(255,255,255,.04);
+  filter: drop-shadow(0 0 28px rgba(168,182,224,.18));
+  animation: foilDrift 14s ease-in-out infinite alternate;
+  transition: background-position .35s ease-out;
+}
+@keyframes foilDrift{
+  0%   { background-position: 0% 30%; }
+  100% { background-position: 100% 70%; }
 }
 .wordmark__sub{
   display:inline-flex; align-items:center; gap:14px;
@@ -365,8 +405,8 @@ a{ color:inherit; text-decoration:none; }
   line-height:1.4;
   color:var(--periwinkle);
   max-width:36ch;
-  opacity:0; transform:translateY(10px);
-  animation: heroIn .9s cubic-bezier(.2,.7,.2,1) 380ms forwards;
+  opacity:0; transform:translateY(28px); filter:blur(8px);
+  animation: heroIn 1.1s cubic-bezier(.2,.7,.2,1) 460ms forwards;
 }
 .hero__lede strong{
   font-family:var(--f-sans);
@@ -378,8 +418,8 @@ a{ color:inherit; text-decoration:none; }
 
 /* Verification stamp */
 .hero__verify{
-  opacity:0; transform:translateY(10px);
-  animation: heroIn .9s cubic-bezier(.2,.7,.2,1) 540ms forwards;
+  opacity:0; transform:translateY(36px) scale(.92); filter:blur(10px);
+  animation: heroIn 1.2s cubic-bezier(.2,.7,.2,1) 660ms forwards;
 }
 .verify-stamp{
   display:inline-flex; align-items:center; gap:18px;
@@ -438,7 +478,7 @@ a{ color:inherit; text-decoration:none; }
   50%     { opacity:1;  transform:translateY(6px); }
 }
 
-@keyframes heroIn{ to{ opacity:1; transform:none; } }
+@keyframes heroIn{ to{ opacity:1; transform:none; filter:blur(0); } }
 
 /* ═══════════════════════════════════════════════════════════════════
    Certificate of Authenticity (COA) — receipt-style data card
@@ -467,12 +507,18 @@ a{ color:inherit; text-decoration:none; }
   padding:0;
   box-shadow:var(--shadow-2);
   overflow:hidden;
-  transform:translateY(48px) scale(.98);
+  transform:translateY(72px) scale(.94);
   opacity:0;
-  transition: opacity 1.1s cubic-bezier(.2,.7,.2,1),
-              transform 1.1s cubic-bezier(.2,.7,.2,1);
+  filter:blur(12px);
+  transition: opacity 1.3s cubic-bezier(.2,.7,.2,1),
+              transform 1.3s cubic-bezier(.2,.7,.2,1),
+              filter 1.3s cubic-bezier(.2,.7,.2,1),
+              box-shadow 1.6s cubic-bezier(.2,.7,.2,1);
 }
-.coa-card.is-in{ opacity:1; transform:none; }
+.coa-card.is-in{
+  opacity:1; transform:none; filter:blur(0);
+  box-shadow:var(--shadow-3);
+}
 
 /* Scan line that sweeps across once on reveal */
 .coa-card::before{
@@ -532,15 +578,20 @@ a{ color:inherit; text-decoration:none; }
   font-size:.7rem;
   letter-spacing:.22em;
   font-weight:600;
-  /* slam-down stamp */
+  /* slam-down stamp — bigger initial scale + rotation, longer overshoot */
   opacity:0;
-  transform:scale(2.6) rotate(-14deg);
-  transition:opacity .5s ease, transform .55s cubic-bezier(.2,1.7,.4,1);
+  transform:scale(3.4) rotate(-22deg);
+  filter:blur(4px);
+  transition:
+    opacity .55s ease,
+    transform .7s cubic-bezier(.2,1.85,.4,1),
+    filter .55s ease;
 }
 .coa-card.is-in .coa-card__seal{
   opacity:1;
   transform:scale(1) rotate(-4deg);
-  transition-delay:1.05s;
+  filter:blur(0);
+  transition-delay:1.15s;
 }
 .coa-card__seal__dot{
   width:8px; height:8px; border-radius:50%;
@@ -614,6 +665,109 @@ a{ color:inherit; text-decoration:none; }
   text-align:right;
 }
 .coa-row dd.mono{ font-size:.86rem; letter-spacing:.02em; }
+
+/* ─────────────────────────────────────────────────────────────────
+   Holographic auth seal — sits on the COA card top-right.
+   Why: a foil/holographic disc (the kind on credit cards & passports)
+   reads instantly as "premium / authentic". Conic gradient base, soft
+   radial highlight on top that tracks the mouse via --hx/--hy.
+   ───────────────────────────────────────────────────────────────── */
+.holo-seal{
+  /* Why: lives in the top-right corner of the card top section, replacing
+     the green "VERIFIED" pill. The seal IS the verified indicator now —
+     foil disc + curved rim text reads as authenticated at a glance. */
+  position:relative;
+  flex-shrink:0;
+  width:clamp(58px, 11vw, 78px);
+  height:clamp(58px, 11vw, 78px);
+  border-radius:50%;
+  display:inline-flex; align-items:center; justify-content:center;
+  pointer-events:none;
+  /* Initial: small + rotated, spins into place on card reveal */
+  opacity:0;
+  transform: scale(.3) rotate(-180deg);
+  transition:
+    opacity .7s ease,
+    transform 1s cubic-bezier(.2,1.6,.4,1);
+  /* Foil base — conic shifts as the disc rotates + as user tilts */
+  background:
+    radial-gradient(circle at var(--hx, 30%) var(--hy, 30%),
+      rgba(255,255,255,.55) 0%,
+      rgba(255,255,255,0)   45%),
+    conic-gradient(from var(--ha, 45deg),
+      #ffd5e8 0deg,
+      #cfd6ee 50deg,
+      #d4f0e6 100deg,
+      #fff5cf 150deg,
+      #cfd6ee 200deg,
+      #ffd5e8 250deg,
+      #d4f0e6 300deg,
+      #cfd6ee 360deg);
+  box-shadow:
+    inset 0 0 0 1px rgba(255,255,255,.55),
+    inset 0 -2px 6px rgba(15,18,38,.18),
+    0 6px 18px rgba(15,18,38,.14),
+    0 0 26px rgba(168,182,224,.30);
+  animation: holoSpin 18s linear infinite;
+}
+.coa-card.is-in .holo-seal{
+  opacity:1;
+  transform: scale(1) rotate(0);
+  transition-delay: 1.05s;
+}
+@keyframes holoSpin{
+  to { --ha: 405deg; }
+}
+@property --ha{ syntax:'<angle>'; inherits:false; initial-value:45deg; }
+
+/* Inner emboss / typography */
+.holo-seal__core{
+  width:72%; height:72%;
+  border-radius:50%;
+  background:
+    radial-gradient(circle at 30% 25%,
+      rgba(255,255,255,.30) 0%,
+      rgba(255,255,255,0) 60%),
+    linear-gradient(180deg, rgba(255,255,255,.35), rgba(255,255,255,.05));
+  border:1px solid rgba(255,255,255,.45);
+  display:flex; align-items:center; justify-content:center;
+  position:relative;
+}
+.holo-seal__core::before{
+  /* faint scan line so the foil reads as 3D */
+  content:"";
+  position:absolute; inset:0;
+  border-radius:50%;
+  background:linear-gradient(180deg,
+    transparent 0%, rgba(255,255,255,.18) 48%,
+    transparent 50%, transparent 100%);
+  mix-blend-mode:overlay;
+  pointer-events:none;
+}
+.holo-seal__svg{ width:60%; height:60%; }
+.holo-seal__svg path,
+.holo-seal__svg circle{
+  fill:none;
+  stroke:#0f1226;
+  stroke-width:1.6;
+  stroke-linecap:round;
+  stroke-linejoin:round;
+  opacity:.78;
+}
+.holo-seal__check{
+  stroke:#0f1226;
+  stroke-width:2;
+  fill:none;
+}
+/* Curved label "AUTHENTIC · RENOVAE LABS · UK ·" around the rim.
+   Why: an SVG <textPath> wrapped on a circular path = passport-stamp feel. */
+.holo-seal__rim text{
+  font-family:var(--f-mono);
+  font-size:7px;
+  letter-spacing:.18em;
+  fill:#0f1226;
+  opacity:.8;
+}
 
 /* Footer of card with barcode-style strip */
 .coa-card__foot{


### PR DESCRIPTION
## Summary

Round-two polish on the Renovae Labs landing based on mobile testing.

## Fixes

- **Hub star covering text** — moved from dead-centre to lower-left quadrant, halo dimmed (was 0.55/16x → now 0.32/9x)
- **Long delay before network animates** — boot overlay is now glassy + blurred so canvas is visible through it from frame 1; total boot 1550ms → 1100ms
- **Latent crash** — clamped perspective denominator. Nodes rotating behind the camera were producing negative draw radii on wide viewports → IndexSizeError → animation stopped silently. Fixed.

## More wow

- Reveals: 28→56px travel, scale 0.96→1, 8px blur unfocus→focus, 1.15s dwell
- Hero entry: wordmark, eyebrow, lede, verify-stamp all upgraded with bigger transforms + blur
- COA card: 12px blur entry, more dramatic stamp slam (3.4× → 1, 22° → -4°)

## New: holographic foil

- **Wordmark** — multi-stop gradient, animated drift, mouse/gyroscope-tracked
- **Holographic auth seal** on COA top-right — conic gradient foil disc with curved "AUTHENTIC · RENOVAE LABS · UK · CERTIFIED" rim text and molecular monogram. Spins into place on card reveal. Foil highlight follows pointer on desktop and device tilt on mobile via DeviceOrientation API.

## Test plan

- [ ] Mobile: boot fades cleanly into hero, network already moving
- [ ] Hero: bright hub no longer behind copy
- [ ] Wordmark: visible silver foil shimmer, drifts subtly on auto + on mouse
- [ ] COA: holographic seal in top-right, curved rim text legible
- [ ] Tilt phone: foil shimmer + seal highlight respond to gyroscope
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)