### PR TITLE
feat(RenovaeLabs): drop boot, spinning helix cue, contact moves up, mobile tilt fix

### DIFF
--- a/public/RenovaeLabs/app.js
+++ b/public/RenovaeLabs/app.js
@@ -65,30 +65,10 @@
   setText('#year',          String(verifiedNow.getFullYear()));
   setText('#coa-product',   productClean || 'Sealed Renovae Labs Unit');
 
-  // ─────────────────────────────────────────────────────────────────
-  // 2. Boot sequence
-  //    Skip if reduced motion. Cache per-session so refresh is instant.
-  // ─────────────────────────────────────────────────────────────────
+  // Why: boot sequence removed — it interfered with the network animation
+  // on mobile (overlay sat in front of the canvas during page load).
+  // The molecular field + page reveals are now the first impression.
   const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const boot = document.getElementById('boot');
-  const seenBoot = sessionStorage.getItem('rnv_seen') === '1';
-
-  if (boot){
-    if (reducedMotion || seenBoot){
-      boot.classList.add('is-done');
-      requestAnimationFrame(() => boot.remove());
-    } else {
-      // Why: was 1550ms which felt like a hold. Boot is now glassy (CSS),
-      // so the molecular network is visible behind it from frame one.
-      // Cut to 1100ms — log still reads, but no perceived "delay" before
-      // the hero reveals itself.
-      setTimeout(() => {
-        boot.classList.add('is-done');
-        sessionStorage.setItem('rnv_seen', '1');
-        setTimeout(() => boot.remove(), 500);
-      }, 1100);
-    }
-  }
 
   // ─────────────────────────────────────────────────────────────────
   // 3. Reveal-on-scroll
@@ -211,9 +191,10 @@
       const passed = vh - r.top;
       const t = Math.max(0, Math.min(1, passed / total));
 
-      // Tilt: -3.5deg (entering) → 0 (centred) → +3.5deg (leaving).
-      // Why: small enough to feel like parallax, not like a gimmick.
-      const tilt = (t - 0.5) * -7;
+      // Tilt: -5deg (entering) → 0 (centred) → +5deg (leaving).
+      // Why: large enough to read on small phones, small enough on
+      // desktop to feel like parallax rather than a gimmick.
+      const tilt = (t - 0.5) * -10;
       coaCardEl.style.setProperty('--tilt-x', tilt.toFixed(2) + 'deg');
 
       // Shimmer band drifts left → right across the card's surface as

--- a/public/RenovaeLabs/index.html
+++ b/public/RenovaeLabs/index.html
@@ -17,7 +17,7 @@
 <link rel="icon" type="image/svg+xml" href="favicon.svg" />
 <link rel="apple-touch-icon" href="favicon.svg" />
 
-<!-- Why: critical fonts preloaded so wordmark doesn't FOIT during boot sequence -->
+<!-- Why: preload display + body fonts so the wordmark doesn't FOIT -->
 <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500;600&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" />
@@ -25,35 +25,6 @@
 <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-
-<!-- ═════════════════════════════════════════════════════════════════
-     Boot sequence — chain-of-custody verification overlay (~1.4s)
-     Why: sells authenticity as the first impression and gives the
-     molecular hero canvas a moment to initialise off-screen.
-═════════════════════════════════════════════════════════════════ -->
-<div class="boot" id="boot" aria-hidden="true">
-  <div class="boot__monogram">
-    <svg viewBox="0 0 60 60" width="56" height="56" aria-hidden="true">
-      <circle cx="30" cy="30" r="28" fill="none" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
-      <circle cx="30" cy="30" r="22" fill="none" stroke="rgba(255,255,255,.28)" stroke-width="1" stroke-dasharray="2 4"/>
-      <circle cx="30" cy="30" r="3" fill="#fff"/>
-      <circle cx="14" cy="22" r="2" fill="rgba(255,255,255,.7)"/>
-      <circle cx="46" cy="38" r="2" fill="rgba(255,255,255,.7)"/>
-      <circle cx="42" cy="14" r="1.5" fill="rgba(255,255,255,.5)"/>
-      <circle cx="18" cy="44" r="1.5" fill="rgba(255,255,255,.5)"/>
-      <line x1="30" y1="30" x2="14" y2="22" stroke="rgba(255,255,255,.35)" stroke-width=".7"/>
-      <line x1="30" y1="30" x2="46" y2="38" stroke="rgba(255,255,255,.35)" stroke-width=".7"/>
-      <line x1="30" y1="30" x2="42" y2="14" stroke="rgba(255,255,255,.25)" stroke-width=".7"/>
-      <line x1="30" y1="30" x2="18" y2="44" stroke="rgba(255,255,255,.25)" stroke-width=".7"/>
-    </svg>
-  </div>
-  <ul class="boot__log" aria-label="Verification sequence">
-    <li><span class="boot__prompt">›</span> Connecting to authentication ledger<span class="boot__dots"></span></li>
-    <li><span class="boot__prompt">›</span> Cross-referencing batch <span data-batch-short>—</span></li>
-    <li><span class="boot__prompt">›</span> Verifying chain of custody</li>
-    <li class="boot__ok"><span class="boot__check">✓</span> Authentic</li>
-  </ul>
-</div>
 
 <!-- ═════════════════════════════════════════════════════════════════
      1. HERO — wordmark, tagline, 3D molecular field, COA card
@@ -123,7 +94,11 @@
 
   <a class="hero__scroll" href="#certificate" aria-label="Scroll to certificate">
     <span>Certificate</span>
-    <span class="hero__scroll__line" aria-hidden="true"></span>
+    <!-- Spinning helix scroll cue — six dots orbit a vertical axis with
+         phase offsets, reading as a rotating peptide coil. -->
+    <span class="hero__scroll__helix" aria-hidden="true">
+      <i></i><i></i><i></i><i></i><i></i><i></i>
+    </span>
   </a>
 </header>
 
@@ -206,12 +181,59 @@
 </section>
 
 <!-- ═════════════════════════════════════════════════════════════════
-     3. PROCESS — Synthesis → Verification → Sealed
+     3. CONTACT — official channels (placed early so anyone unsure can
+     reach the source immediately after verifying)
+═════════════════════════════════════════════════════════════════ -->
+<section class="contact" id="contact">
+  <div class="container">
+    <header class="section-head reveal">
+      <span class="eyebrow eyebrow--light">§02 — Official Channels</span>
+      <h2 class="display display--light">Stay close to the source.</h2>
+      <p class="lead lead--light">For product questions, supply enquiries, or
+        verification concerns — reach us through our official channels only.
+        Anything else is not us.</p>
+    </header>
+
+    <div class="contact__grid reveal">
+      <a class="channel" href="https://www.instagram.com/renovae_labs_uk?igsh=dnRuc2plemZlbWc3" target="_blank" rel="noopener noreferrer">
+        <div class="channel__icon">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="5" y="5" width="22" height="22" rx="6"/>
+            <circle cx="16" cy="16" r="5"/>
+            <circle cx="23" cy="9" r="1.2" fill="currentColor"/>
+          </svg>
+        </div>
+        <div class="channel__text">
+          <span class="channel__label">Instagram</span>
+          <span class="channel__value">@renovae_labs_uk</span>
+        </div>
+        <span class="channel__arrow" aria-hidden="true">→</span>
+      </a>
+
+      <a class="channel" href="mailto:info@renovaelabs.com">
+        <div class="channel__icon">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="7" width="24" height="18" rx="2"/>
+            <path d="M4 9 L16 18 L28 9"/>
+          </svg>
+        </div>
+        <div class="channel__text">
+          <span class="channel__label">Email</span>
+          <span class="channel__value">info@renovaelabs.com</span>
+        </div>
+        <span class="channel__arrow" aria-hidden="true">→</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════════════════════════════════════════════════════════
+     4. PROCESS — Synthesis → Verification → Sealed
 ═════════════════════════════════════════════════════════════════ -->
 <section class="process">
   <div class="container">
     <header class="section-head reveal">
-      <span class="eyebrow">§02 — Process</span>
+      <span class="eyebrow">§03 — Process</span>
       <h2 class="display">Three stages.<br/><em>Zero shortcuts.</em></h2>
       <p class="lead">From synthesis to sealed packaging, every unit passes through
       a documented chain — built so that authenticity is provable, not promised.</p>
@@ -263,7 +285,7 @@
 <section class="trust">
   <div class="container">
     <header class="section-head reveal">
-      <span class="eyebrow">§03 — Standards</span>
+      <span class="eyebrow">§04 — Standards</span>
       <h2 class="display">What we hold ourselves to.</h2>
       <p class="lead">No over-claiming. No marketing fluff. Just the
         operating discipline behind every sealed unit.</p>
@@ -353,7 +375,7 @@
 <section class="specs">
   <div class="container">
     <header class="section-head reveal">
-      <span class="eyebrow eyebrow--light">§04 — Release Specifications</span>
+      <span class="eyebrow eyebrow--light">§05 — Release Specifications</span>
       <h2 class="display display--light">Built to specification.<br/>Released against it.</h2>
     </header>
 
@@ -395,7 +417,7 @@
 <section class="about">
   <div class="container about__wrap">
     <header class="section-head reveal">
-      <span class="eyebrow">§05 — About</span>
+      <span class="eyebrow">§06 — About</span>
       <h2 class="display">Lab-led. Precision-built.<br/><em>Quietly obsessive.</em></h2>
     </header>
 
@@ -416,53 +438,7 @@
 </section>
 
 <!-- ═════════════════════════════════════════════════════════════════
-     7. CONTACT — official channels
-═════════════════════════════════════════════════════════════════ -->
-<section class="contact">
-  <div class="container">
-    <header class="section-head reveal">
-      <span class="eyebrow eyebrow--light">§06 — Official Channels</span>
-      <h2 class="display display--light">Stay close to the source.</h2>
-      <p class="lead lead--light">For product questions, supply enquiries, or
-        verification concerns — reach us through our official channels only.
-        Anything else is not us.</p>
-    </header>
-
-    <div class="contact__grid reveal">
-      <a class="channel" href="https://www.instagram.com/renovae_labs_uk?igsh=dnRuc2plemZlbWc3" target="_blank" rel="noopener noreferrer">
-        <div class="channel__icon">
-          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="5" y="5" width="22" height="22" rx="6"/>
-            <circle cx="16" cy="16" r="5"/>
-            <circle cx="23" cy="9" r="1.2" fill="currentColor"/>
-          </svg>
-        </div>
-        <div class="channel__text">
-          <span class="channel__label">Instagram</span>
-          <span class="channel__value">@renovae_labs_uk</span>
-        </div>
-        <span class="channel__arrow" aria-hidden="true">→</span>
-      </a>
-
-      <a class="channel" href="mailto:info@renovaelabs.com">
-        <div class="channel__icon">
-          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="4" y="7" width="24" height="18" rx="2"/>
-            <path d="M4 9 L16 18 L28 9"/>
-          </svg>
-        </div>
-        <div class="channel__text">
-          <span class="channel__label">Email</span>
-          <span class="channel__value">info@renovaelabs.com</span>
-        </div>
-        <span class="channel__arrow" aria-hidden="true">→</span>
-      </a>
-    </div>
-  </div>
-</section>
-
-<!-- ═════════════════════════════════════════════════════════════════
-     8. DISCLAIMER + FOOTER
+     7. DISCLAIMER + FOOTER
 ═════════════════════════════════════════════════════════════════ -->
 <footer class="footer">
   <div class="container">

--- a/public/RenovaeLabs/styles.css
+++ b/public/RenovaeLabs/styles.css
@@ -153,102 +153,6 @@ a{ color:inherit; text-decoration:none; }
 }
 
 /* ═══════════════════════════════════════════════════════════════════
-   Boot sequence — full-screen verification overlay
-═══════════════════════════════════════════════════════════════════ */
-.boot{
-  position:fixed; inset:0; z-index:100;
-  /* Why: glassy + blurred — molecular network behind it animates from
-     frame one, so by the time the boot fades there's no "dead" beat
-     where the hero feels static. */
-  background:linear-gradient(180deg, rgba(13,18,49,.78) 0%, rgba(6,8,26,.82) 100%);
-  backdrop-filter:blur(14px) saturate(1.1);
-  -webkit-backdrop-filter:blur(14px) saturate(1.1);
-  color:#dde3f5;
-  display:flex; flex-direction:column; align-items:center; justify-content:center;
-  gap:32px;
-  padding:24px;
-  font-family:var(--f-mono);
-  pointer-events:none;
-  transition:opacity .5s ease, visibility .5s, backdrop-filter .5s ease;
-}
-.boot.is-done{
-  opacity:0; visibility:hidden;
-  backdrop-filter:blur(0) saturate(1);
-  -webkit-backdrop-filter:blur(0) saturate(1);
-}
-
-.boot__monogram{
-  opacity:0;
-  animation: bootMono 600ms ease-out 100ms forwards;
-}
-@keyframes bootMono{
-  0%   { opacity:0; transform:scale(.9) rotate(-8deg); }
-  60%  { opacity:1; transform:scale(1.04) rotate(0); }
-  100% { opacity:1; transform:scale(1) rotate(0); }
-}
-.boot__monogram svg{ animation: bootSpin 8s linear infinite; }
-@keyframes bootSpin{ to{ transform:rotate(360deg); } }
-
-.boot__log{
-  list-style:none; padding:0; margin:0;
-  font-size:.78rem;
-  letter-spacing:.04em;
-  color:rgba(207,214,238,.85);
-  display:flex; flex-direction:column;
-  gap:10px;
-  min-width:min(320px, 90vw);
-  text-align:left;
-}
-.boot__log li{
-  opacity:0;
-  transform:translateX(-6px);
-  animation: bootLog 380ms cubic-bezier(.2,.7,.2,1) forwards;
-}
-/* Why: tightened from 300/560/820/1080 to fit the new 1100ms boot window */
-.boot__log li:nth-child(1){ animation-delay:180ms; }
-.boot__log li:nth-child(2){ animation-delay:340ms; }
-.boot__log li:nth-child(3){ animation-delay:500ms; }
-.boot__log li:nth-child(4){ animation-delay:660ms; }
-@keyframes bootLog{ to{ opacity:1; transform:none; } }
-.boot__prompt{
-  display:inline-block;
-  width:14px;
-  color:var(--indigo);
-  margin-right:6px;
-}
-.boot__dots::after{
-  content:"...";
-  display:inline-block;
-  margin-left:4px;
-  animation: bootDots .9s steps(4) infinite;
-}
-@keyframes bootDots{ to{ clip-path: inset(0 0 0 100%); } }
-
-.boot__ok{
-  margin-top:6px;
-  color:#7be0bf;
-  font-weight:600;
-  letter-spacing:.18em;
-  text-transform:uppercase;
-}
-.boot__check{
-  display:inline-block;
-  width:18px; height:18px; border-radius:50%;
-  background:var(--verified);
-  color:#fff;
-  font-size:.7rem; line-height:18px;
-  text-align:center;
-  margin-right:10px;
-  box-shadow:0 0 0 0 rgba(31,142,108,.5);
-  animation: bootPulse 1.0s ease-out 660ms 1;
-}
-@keyframes bootPulse{
-  0%   { box-shadow:0 0 0 0 rgba(31,142,108,.55); }
-  60%  { box-shadow:0 0 0 18px rgba(31,142,108,0); }
-  100% { box-shadow:0 0 0 0 rgba(31,142,108,0); }
-}
-
-/* ═══════════════════════════════════════════════════════════════════
    Hero
 ═══════════════════════════════════════════════════════════════════ */
 .hero{
@@ -459,7 +363,7 @@ a{ color:inherit; text-decoration:none; }
 .hero__scroll{
   position:relative; z-index:3;
   margin: 0 auto;
-  display:inline-flex; flex-direction:column; align-items:center; gap:10px;
+  display:inline-flex; flex-direction:column; align-items:center; gap:14px;
   font-family:var(--f-mono);
   font-size:.68rem;
   letter-spacing:.32em;
@@ -468,14 +372,38 @@ a{ color:inherit; text-decoration:none; }
   opacity:0;
   animation: heroIn .9s ease 800ms forwards;
 }
-.hero__scroll__line{
-  width:1px; height:42px;
-  background:linear-gradient(to bottom, rgba(255,255,255,.6), transparent);
-  animation: cueDrip 2.4s ease-in-out infinite;
+/* Spinning peptide helix — six dots orbit a vertical axis with phase
+   offsets, reading as a rotating coil. Why: replaces the previous
+   bouncing line cue with something that nods to the molecular brand. */
+.hero__scroll__helix{
+  position:relative;
+  width:30px;
+  height:60px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:space-between;
+  padding:2px 0;
 }
-@keyframes cueDrip{
-  0%,100% { opacity:.3; transform:translateY(-4px); }
-  50%     { opacity:1;  transform:translateY(6px); }
+.hero__scroll__helix i{
+  display:block;
+  width:5px; height:5px; border-radius:50%;
+  background:rgba(255,255,255,.85);
+  box-shadow:0 0 6px rgba(207,214,238,.45);
+  animation: helixOrbit 1.6s ease-in-out infinite;
+}
+.hero__scroll__helix i:nth-child(1){ animation-delay:0s; }
+.hero__scroll__helix i:nth-child(2){ animation-delay:-.18s; }
+.hero__scroll__helix i:nth-child(3){ animation-delay:-.36s; }
+.hero__scroll__helix i:nth-child(4){ animation-delay:-.54s; }
+.hero__scroll__helix i:nth-child(5){ animation-delay:-.72s; }
+.hero__scroll__helix i:nth-child(6){ animation-delay:-.90s; }
+@keyframes helixOrbit{
+  0%   { transform:translateX(-9px) scale(.55); opacity:.25; }
+  25%  { transform:translateX(0)    scale(1.15); opacity:1;  }
+  50%  { transform:translateX(9px)  scale(.55); opacity:.25; }
+  75%  { transform:translateX(0)    scale(1.15); opacity:1;  }
+  100% { transform:translateX(-9px) scale(.55); opacity:.25; }
 }
 
 @keyframes heroIn{ to{ opacity:1; transform:none; filter:blur(0); } }
@@ -498,11 +426,12 @@ a{ color:inherit; text-decoration:none; }
 .coa__wrap{ position:relative; }
 
 /* The receipt card
-   Why: combines two effects driven by JS-set CSS vars:
-   • --reveal-* drives the entry transition (translateY + scale + blur)
-   • --tilt-x / --shimmer drive a continuous, scroll-linked parallax
-     where the card subtly tilts on its X axis and a foil band drifts
-     across its surface as the user scrolls past. */
+   Why: tilt + shimmer are scroll-linked via JS-set CSS vars (--tilt-x,
+   --shimmer). Entry uses a keyframe animation rather than a transform
+   transition — that previously fought the live tilt updates on mobile
+   (each scroll event triggered a 0.4s re-transition, leaving the card
+   permanently chasing the scroll position). With keyframe-driven entry
+   the transform reads --tilt-x live, every paint. */
 .coa-card{
   position:relative;
   margin-top:48px;
@@ -515,13 +444,13 @@ a{ color:inherit; text-decoration:none; }
   opacity:0;
   filter:blur(12px);
   transform-origin: 50% 80%;
+  /* Resting state (pre-reveal): off-screen slightly, scaled, tilted */
   transform:
     perspective(1400px)
-    translateY(var(--reveal-y, 72px))
-    scale(var(--reveal-s, .94))
+    translateY(72px)
+    scale(.94)
     rotateX(var(--tilt-x, 0deg));
   transition: opacity 1.3s cubic-bezier(.2,.7,.2,1),
-              transform .4s cubic-bezier(.2,.7,.2,1),
               filter 1.3s cubic-bezier(.2,.7,.2,1),
               box-shadow 1.6s cubic-bezier(.2,.7,.2,1);
 }
@@ -529,8 +458,16 @@ a{ color:inherit; text-decoration:none; }
   opacity:1;
   filter:blur(0);
   box-shadow:var(--shadow-3);
-  --reveal-y:0px;
-  --reveal-s:1;
+  animation: coaCardEntry 1.3s cubic-bezier(.2,.7,.2,1) forwards;
+}
+@keyframes coaCardEntry{
+  to{
+    transform:
+      perspective(1400px)
+      translateY(0)
+      scale(1)
+      rotateX(var(--tilt-x, 0deg));
+  }
 }
 
 /* Scan line that sweeps across once on reveal */


### PR DESCRIPTION
Four small fixes from mobile testing:

- **Drop boot overlay** — was blocking the molecular animation on mobile load
- **Spinning helix scroll cue** — six dots orbiting a vertical axis (replaces the bouncing line)
- **Contact moves to §02** — right after the Certificate, before Process. So if anything looks off, the contact channels are reachable immediately
- **COA tilt now works on mobile** — replaced the 0.4s transform transition with a CSS keyframe entry; the transform now reads --tilt-x live every paint instead of chasing the scroll. Tilt range bumped to ±5°.

🤖 Generated with [Claude Code](https://claude.com/claude-code)