### PR TITLE
feat(RenovaeLabs): holo card, double helix, checking→confirmed, reliability fixes

### DIFF
--- a/public/RenovaeLabs/app.js
+++ b/public/RenovaeLabs/app.js
@@ -161,15 +161,11 @@
     });
   }, { passive:true });
 
-  if ('DeviceOrientationEvent' in window){
-    window.addEventListener('deviceorientation', (e) => {
-      // gamma -90..90 = left-right tilt; beta -180..180 = front-back
-      const gx = ((e.gamma + 45) / 90) * 100;
-      const gy = ((e.beta  + 30) / 90) * 100;
-      root.style.setProperty('--foil-x', Math.max(0, Math.min(100, gx)) + '%');
-      root.style.setProperty('--foil-y', Math.max(0, Math.min(100, gy)) + '%');
-    }, { passive:true });
-  }
+  // Why: removed DeviceOrientation gyroscope tracking. iOS Safari was
+  // surfacing the "Advanced Tracking and Fingerprinting Protection"
+  // banner whenever the listener was attached, even without permission.
+  // The wordmark foil still animates via CSS keyframes (foilDrift), and
+  // pointer-tracking continues to work on desktop. That's enough.
 
   // ─────────────────────────────────────────────────────────────────
   // 5b. COA card — scroll-linked tilt + shimmer band
@@ -191,16 +187,19 @@
       const passed = vh - r.top;
       const t = Math.max(0, Math.min(1, passed / total));
 
-      // Tilt: -5deg (entering) → 0 (centred) → +5deg (leaving).
-      // Why: large enough to read on small phones, small enough on
-      // desktop to feel like parallax rather than a gimmick.
-      const tilt = (t - 0.5) * -10;
-      coaCardEl.style.setProperty('--tilt-x', tilt.toFixed(2) + 'deg');
+      // Tilt X: -7deg (entering) → 0 (centred) → +7deg (leaving).
+      // Tilt Y: ±4deg sinusoidal wobble across the same scroll range.
+      // Why: combined X + Y axis tilt with a phase-offset Y wobble
+      // gives the card a holo-card-in-hand feel — it shifts as the user
+      // moves past it, not just nods forward and back.
+      const tiltX = (t - 0.5) * -14;
+      const tiltY = Math.sin(t * Math.PI * 2) * 4;
+      coaCardEl.style.setProperty('--tilt-x', tiltX.toFixed(2) + 'deg');
+      coaCardEl.style.setProperty('--tilt-y', tiltY.toFixed(2) + 'deg');
 
-      // Shimmer band drifts left → right across the card's surface as
-      // the section travels through the viewport. 8% .. 92% so the band
-      // is always partially on-card.
-      const shimmer = 8 + t * 84;
+      // Holo glisten band drifts left → right across the card's surface
+      // as the section travels through the viewport.
+      const shimmer = 6 + t * 88;
       coaCardEl.style.setProperty('--shimmer', shimmer.toFixed(1) + '%');
     };
     const onScroll = () => {
@@ -425,6 +424,22 @@
     clearTimeout(rT);
     rT = setTimeout(resize, 120);
   }, { passive:true });
+
+  // Why: on iOS Safari (and sometimes Android Chrome), defer scripts can
+  // run before the canvas has its laid-out dimensions. resize() then
+  // measures 0×0, seeds zero nodes, and the canvas stays blank until the
+  // user reloads. Watching the canvas with ResizeObserver guarantees we
+  // re-seed once real dimensions land. We also kick again on load.
+  if ('ResizeObserver' in window){
+    const ro = new ResizeObserver(() => resize());
+    ro.observe(canvas);
+  }
+  window.addEventListener('load', () => {
+    requestAnimationFrame(() => {
+      resize();
+      if (!raf){ running = true; raf = requestAnimationFrame(tick); }
+    });
+  }, { once:true });
 
   resize();
   raf = requestAnimationFrame(tick);

--- a/public/RenovaeLabs/index.html
+++ b/public/RenovaeLabs/index.html
@@ -82,11 +82,20 @@
         <svg viewBox="0 0 100 100" width="58" height="58" aria-hidden="true">
           <circle cx="50" cy="50" r="46" fill="none" stroke="currentColor" stroke-width="1.4" opacity=".4"/>
           <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width=".8" stroke-dasharray="3 5" opacity=".55"/>
+          <!-- Spinner arc — visible while checking, fades out on confirm -->
+          <circle class="verify-stamp__spinner" cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="2.6" stroke-dasharray="55 200" stroke-linecap="round" opacity=".85"/>
+          <!-- Check — draws in once authentication completes -->
           <path class="verify-stamp__check" d="M32 52 L44 64 L70 36" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
         <div class="verify-stamp__text">
-          <span class="verify-stamp__label">Authenticity</span>
-          <span class="verify-stamp__status">Confirmed</span>
+          <span class="verify-stamp__state verify-stamp__state--checking">
+            <span class="verify-stamp__label">Verification</span>
+            <span class="verify-stamp__status">Checking…</span>
+          </span>
+          <span class="verify-stamp__state verify-stamp__state--confirmed">
+            <span class="verify-stamp__label">Authenticity</span>
+            <span class="verify-stamp__status">Confirmed</span>
+          </span>
         </div>
       </div>
     </div>
@@ -94,10 +103,15 @@
 
   <a class="hero__scroll" href="#certificate" aria-label="Scroll to certificate">
     <span>Certificate</span>
-    <!-- Spinning helix scroll cue — six dots orbit a vertical axis with
-         phase offsets, reading as a rotating peptide coil. -->
+    <!-- Spinning double helix scroll cue — five rungs, each with two dots
+         that swap positions across the rung. Phase offset between rungs
+         creates the rotating ladder / DNA double-helix illusion. -->
     <span class="hero__scroll__helix" aria-hidden="true">
-      <i></i><i></i><i></i><i></i><i></i><i></i>
+      <span class="rung"><i></i><i></i></span>
+      <span class="rung"><i></i><i></i></span>
+      <span class="rung"><i></i><i></i></span>
+      <span class="rung"><i></i><i></i></span>
+      <span class="rung"><i></i><i></i></span>
     </span>
   </a>
 </header>

--- a/public/RenovaeLabs/styles.css
+++ b/public/RenovaeLabs/styles.css
@@ -337,13 +337,58 @@ a{ color:inherit; text-decoration:none; }
   box-shadow: 0 12px 40px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.10);
 }
 .verify-stamp svg{ color:var(--verified); }
+
+/* Why: stamp boots in a "Checking…" state with a rotating spinner arc,
+   then flips to "Confirmed" with the check drawing in. Two delays drive
+   the choreography: 1.25s holds the checking state, then everything
+   transitions over the next 0.7s. */
+.verify-stamp__spinner{
+  color:var(--periwinkle);
+  transform-origin:50% 50%;
+  animation:
+    verifySpin   1s linear infinite,
+    verifySpinOut .35s ease 1.20s forwards;
+}
 .verify-stamp__check{
   stroke-dasharray:60;
   stroke-dashoffset:60;
-  animation: drawCheck .9s cubic-bezier(.2,.7,.2,1) 1.6s forwards;
+  animation: drawCheck .85s cubic-bezier(.2,.7,.2,1) 1.45s forwards;
 }
+@keyframes verifySpin{ to{ transform:rotate(360deg); } }
+@keyframes verifySpinOut{ to{ opacity:0; } }
 @keyframes drawCheck{ to{ stroke-dashoffset:0; } }
-.verify-stamp__text{ display:flex; flex-direction:column; align-items:flex-start; }
+
+/* Two text states stacked — fade between them on the same timeline as
+   the spinner-out / check-in transition. */
+.verify-stamp__text{
+  position:relative;
+  display:block;
+  min-width:130px;
+  height:38px;
+}
+.verify-stamp__state{
+  position:absolute;
+  inset:0;
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  justify-content:center;
+}
+.verify-stamp__state--checking{
+  animation: stampOut .35s ease 1.20s forwards;
+}
+.verify-stamp__state--confirmed{
+  opacity:0;
+  transform:translateY(6px);
+  animation: stampIn .55s cubic-bezier(.2,.7,.2,1) 1.45s forwards;
+}
+@keyframes stampOut{
+  to{ opacity:0; transform:translateY(-6px); }
+}
+@keyframes stampIn{
+  to{ opacity:1; transform:translateY(0); }
+}
+
 .verify-stamp__label{
   font-family:var(--f-mono);
   font-size:.66rem;
@@ -372,38 +417,49 @@ a{ color:inherit; text-decoration:none; }
   opacity:0;
   animation: heroIn .9s ease 800ms forwards;
 }
-/* Spinning peptide helix — six dots orbit a vertical axis with phase
-   offsets, reading as a rotating coil. Why: replaces the previous
-   bouncing line cue with something that nods to the molecular brand. */
+/* Double helix scroll cue — five rungs, two dots per rung, swap
+   positions in opposition. Phase offset between rungs spirals it. */
 .hero__scroll__helix{
   position:relative;
-  width:30px;
-  height:60px;
+  width:18px;
+  height:50px;
   display:flex;
   flex-direction:column;
-  align-items:center;
   justify-content:space-between;
   padding:2px 0;
 }
-.hero__scroll__helix i{
-  display:block;
-  width:5px; height:5px; border-radius:50%;
-  background:rgba(255,255,255,.85);
-  box-shadow:0 0 6px rgba(207,214,238,.45);
-  animation: helixOrbit 1.6s ease-in-out infinite;
+.hero__scroll__helix .rung{
+  position:relative;
+  width:100%;
+  height:3px;
 }
-.hero__scroll__helix i:nth-child(1){ animation-delay:0s; }
-.hero__scroll__helix i:nth-child(2){ animation-delay:-.18s; }
-.hero__scroll__helix i:nth-child(3){ animation-delay:-.36s; }
-.hero__scroll__helix i:nth-child(4){ animation-delay:-.54s; }
-.hero__scroll__helix i:nth-child(5){ animation-delay:-.72s; }
-.hero__scroll__helix i:nth-child(6){ animation-delay:-.90s; }
-@keyframes helixOrbit{
-  0%   { transform:translateX(-9px) scale(.55); opacity:.25; }
-  25%  { transform:translateX(0)    scale(1.15); opacity:1;  }
-  50%  { transform:translateX(9px)  scale(.55); opacity:.25; }
-  75%  { transform:translateX(0)    scale(1.15); opacity:1;  }
-  100% { transform:translateX(-9px) scale(.55); opacity:.25; }
+.hero__scroll__helix .rung i{
+  position:absolute;
+  top:0; left:0;
+  width:3px; height:3px; border-radius:50%;
+  background:rgba(255,255,255,.85);
+  box-shadow:0 0 5px rgba(207,214,238,.45);
+  animation-duration:1.7s;
+  animation-iteration-count:infinite;
+  animation-timing-function:ease-in-out;
+}
+/* Strand A — left → right → left, "in front" half the cycle */
+.hero__scroll__helix .rung i:nth-child(1){ animation-name:dnaA; }
+/* Strand B — right → left → right, anti-phase */
+.hero__scroll__helix .rung i:nth-child(2){ animation-name:dnaB; }
+/* Phase offset per rung gives the spiral direction */
+.hero__scroll__helix .rung:nth-child(1) i{ animation-delay:0s; }
+.hero__scroll__helix .rung:nth-child(2) i{ animation-delay:-.34s; }
+.hero__scroll__helix .rung:nth-child(3) i{ animation-delay:-.68s; }
+.hero__scroll__helix .rung:nth-child(4) i{ animation-delay:-1.02s; }
+.hero__scroll__helix .rung:nth-child(5) i{ animation-delay:-1.36s; }
+@keyframes dnaA{
+  0%,100% { transform:translateX(0)    scale(1.15); opacity:1;   }
+  50%     { transform:translateX(15px) scale(.55);  opacity:.25; }
+}
+@keyframes dnaB{
+  0%,100% { transform:translateX(15px) scale(.55);  opacity:.25; }
+  50%     { transform:translateX(0)    scale(1.15); opacity:1;   }
 }
 
 @keyframes heroIn{ to{ opacity:1; transform:none; filter:blur(0); } }
@@ -443,13 +499,15 @@ a{ color:inherit; text-decoration:none; }
   overflow:hidden;
   opacity:0;
   filter:blur(12px);
-  transform-origin: 50% 80%;
-  /* Resting state (pre-reveal): off-screen slightly, scaled, tilted */
+  transform-origin: 50% 50%;
+  /* Resting state (pre-reveal): off-screen slightly, scaled, tilted on
+     both axes — gives a holo-card-in-hand feel as the user scrolls. */
   transform:
     perspective(1400px)
     translateY(72px)
     scale(.94)
-    rotateX(var(--tilt-x, 0deg));
+    rotateX(var(--tilt-x, 0deg))
+    rotateY(var(--tilt-y, 0deg));
   transition: opacity 1.3s cubic-bezier(.2,.7,.2,1),
               filter 1.3s cubic-bezier(.2,.7,.2,1),
               box-shadow 1.6s cubic-bezier(.2,.7,.2,1);
@@ -466,7 +524,8 @@ a{ color:inherit; text-decoration:none; }
       perspective(1400px)
       translateY(0)
       scale(1)
-      rotateX(var(--tilt-x, 0deg));
+      rotateX(var(--tilt-x, 0deg))
+      rotateY(var(--tilt-y, 0deg));
   }
 }
 
@@ -493,9 +552,9 @@ a{ color:inherit; text-decoration:none; }
   100% { left:130%; opacity:0; }
 }
 
-/* Scroll-linked shimmer band — the bright stripe glides across the card
-   as the section scrolls through the viewport. Position controlled via
-   --shimmer (0%..100%) set from JS. Card sits behind, shimmer on top. */
+/* Holo glisten — bright stripe glides across the card as the section
+   scrolls through the viewport. Peak alpha bumped to 0.8 so the band
+   reads clearly as a foil glisten, not a subtle highlight. */
 .coa-card::after{
   content:"";
   position:absolute; inset:0;
@@ -503,11 +562,11 @@ a{ color:inherit; text-decoration:none; }
   z-index:3;
   opacity:0;
   background:linear-gradient(115deg,
-    transparent calc(var(--shimmer, 50%) - 22%),
-    rgba(255,255,255,.10) calc(var(--shimmer, 50%) - 8%),
-    rgba(180,200,240,.42)  var(--shimmer, 50%),
-    rgba(255,255,255,.10) calc(var(--shimmer, 50%) + 8%),
-    transparent calc(var(--shimmer, 50%) + 22%));
+    transparent calc(var(--shimmer, 50%) - 24%),
+    rgba(255,255,255,.30) calc(var(--shimmer, 50%) - 9%),
+    rgba(180,200,240,.80)  var(--shimmer, 50%),
+    rgba(255,255,255,.30) calc(var(--shimmer, 50%) + 9%),
+    transparent calc(var(--shimmer, 50%) + 24%));
   mix-blend-mode: overlay;
   transition: opacity .6s ease;
 }


### PR DESCRIPTION
Five changes from mobile feedback:

- **Holo card** — COA tilts ±7° X + ±4° Y wobble, glisten alpha bumped to 0.80
- **Double helix** scroll cue — slimmer DNA-style with two strands per rung, swapping in opposition
- **'Checking...' → 'Confirmed'** — verify stamp boots with a rotating spinner + 'Verification / Checking…', then flips to 'Authenticity / Confirmed' with the check drawing in
- **Fix Safari 'Reduce Protections' banner** — removed DeviceOrientation listener that was triggering it
- **Fix blank-on-first-load canvas** — ResizeObserver + load-event kick so the network always seeds once real dimensions land

🤖 Generated with [Claude Code](https://claude.com/claude-code)