### PR TITLE
fix(RenovaeLabs): redirect lowercase URL to canonical case

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,20 @@ const nextConfig: NextConfig = {
       { source: '/RenovaeLabs/',     destination: '/RenovaeLabs/index.html' },
     ];
   },
+
+  // Redirect common lowercase variants to the canonical CamelCase path.
+  // Why: case-insensitive matchers in some upstream proxies (and in some
+  // QR/typed entries) sent /renovaelabs/ through, which served the HTML
+  // but resolved relative asset URLs against the lowercase prefix —
+  // styles.css and app.js then 404'd. A permanent redirect normalises
+  // the URL in the address bar so all asset paths resolve.
+  async redirects() {
+    return [
+      { source: '/renovaelabs',  destination: '/RenovaeLabs/', permanent: true },
+      { source: '/renovaelabs/', destination: '/RenovaeLabs/', permanent: true },
+      { source: '/renovaelabs/:path*', destination: '/RenovaeLabs/:path*', permanent: true },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Hot fix. /renovaelabs/ was serving the HTML but relative asset URLs (styles.css, app.js, favicon.svg) resolved against the lowercase prefix and 404'd. 308-redirect to canonical /RenovaeLabs/ so the browser lands on the correct case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)