### PR TITLE
feat(renovaelabs): random 200-500ms jitter on verify stamp confirmation

### DIFF
--- a/public/renovaelabs/app.js
+++ b/public/renovaelabs/app.js
@@ -142,6 +142,24 @@
   }
 
   // ─────────────────────────────────────────────────────────────────
+  // 4b. Verify stamp — random-jitter checking → confirmed flip
+  //     Why: a fixed 1.25s delay every visit feels canned. Real auth
+  //     systems take a slightly different time each request. Adding
+  //     200–500ms of jitter on top of an 850ms base delay gives the
+  //     stamp a "real verification just happened" feel.
+  // ─────────────────────────────────────────────────────────────────
+  const verifyStamp = document.querySelector('.verify-stamp');
+  if (verifyStamp){
+    if (reducedMotion){
+      verifyStamp.classList.add('is-confirmed');
+    } else {
+      const base   = 850;
+      const jitter = 200 + Math.random() * 300;
+      setTimeout(() => verifyStamp.classList.add('is-confirmed'), base + jitter);
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────
   // 5. Wordmark foil — mouse / device-tilt tracking
   //    Why: drifts the foil gradient under cursor / device tilt so the
   //    wordmark reads like a real foil under a real light source.

--- a/public/renovaelabs/styles.css
+++ b/public/renovaelabs/styles.css
@@ -339,20 +339,27 @@ a{ color:inherit; text-decoration:none; }
 .verify-stamp svg{ color:var(--verified); }
 
 /* Why: stamp boots in a "Checking…" state with a rotating spinner arc,
-   then flips to "Confirmed" with the check drawing in. Two delays drive
-   the choreography: 1.25s holds the checking state, then everything
-   transitions over the next 0.7s. */
+   then flips to "Confirmed" with the check drawing in. The confirm
+   trigger is JS-driven (.is-confirmed class added with a random
+   200–500ms jitter on top of a base delay) so the verification never
+   takes the exact same time twice — reads as a real check, not a
+   pre-baked animation. */
 .verify-stamp__spinner{
   color:var(--periwinkle);
   transform-origin:50% 50%;
+  animation: verifySpin 1s linear infinite;
+}
+.verify-stamp.is-confirmed .verify-stamp__spinner{
   animation:
     verifySpin   1s linear infinite,
-    verifySpinOut .35s ease 1.20s forwards;
+    verifySpinOut .35s ease forwards;
 }
 .verify-stamp__check{
   stroke-dasharray:60;
   stroke-dashoffset:60;
-  animation: drawCheck .85s cubic-bezier(.2,.7,.2,1) 1.45s forwards;
+}
+.verify-stamp.is-confirmed .verify-stamp__check{
+  animation: drawCheck .85s cubic-bezier(.2,.7,.2,1) .25s forwards;
 }
 @keyframes verifySpin{ to{ transform:rotate(360deg); } }
 @keyframes verifySpinOut{ to{ opacity:0; } }
@@ -374,13 +381,15 @@ a{ color:inherit; text-decoration:none; }
   align-items:flex-start;
   justify-content:center;
 }
-.verify-stamp__state--checking{
-  animation: stampOut .35s ease 1.20s forwards;
-}
 .verify-stamp__state--confirmed{
   opacity:0;
   transform:translateY(6px);
-  animation: stampIn .55s cubic-bezier(.2,.7,.2,1) 1.45s forwards;
+}
+.verify-stamp.is-confirmed .verify-stamp__state--checking{
+  animation: stampOut .35s ease forwards;
+}
+.verify-stamp.is-confirmed .verify-stamp__state--confirmed{
+  animation: stampIn .55s cubic-bezier(.2,.7,.2,1) .25s forwards;
 }
 @keyframes stampOut{
   to{ opacity:0; transform:translateY(-6px); }


### PR DESCRIPTION
Adds 200–500ms of random jitter to the 'Checking…' → 'Confirmed' flip so each scan takes a slightly different time. Reads as a real verification rather than a baked animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)