### PR TITLE
feat(renovaelabs): hero contact icons — Instagram + email under 'Authenticated'

### DIFF
--- a/public/renovaelabs/index.html
+++ b/public/renovaelabs/index.html
@@ -50,10 +50,27 @@
       </span>
       <span class="hero__brand__text">RENOVAE</span>
     </a>
-    <span class="hero__pill" aria-hidden="true">
-      <span class="hero__pill__dot"></span>
-      Authenticated
-    </span>
+    <div class="hero__nav__right">
+      <span class="hero__pill" aria-hidden="true">
+        <span class="hero__pill__dot"></span>
+        Authenticated
+      </span>
+      <div class="hero__channels" aria-label="Contact channels">
+        <a class="hero__channel" href="https://www.instagram.com/renovae_labs_uk?igsh=dnRuc2plemZlbWc3" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="18" rx="5"/>
+            <circle cx="12" cy="12" r="4"/>
+            <circle cx="17.5" cy="6.5" r="1" fill="currentColor"/>
+          </svg>
+        </a>
+        <a class="hero__channel" href="mailto:info@renovaelabs.com" aria-label="Email">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="5" width="18" height="14" rx="2"/>
+            <path d="M3 7l9 6 9-6"/>
+          </svg>
+        </a>
+      </div>
+    </div>
   </nav>
 
   <div class="hero__inner">

--- a/public/renovaelabs/styles.css
+++ b/public/renovaelabs/styles.css
@@ -187,9 +187,35 @@ a{ color:inherit; text-decoration:none; }
 /* Top nav */
 .hero__nav{
   position:relative; z-index:3;
-  display:flex; align-items:center; justify-content:space-between;
+  display:flex; align-items:flex-start; justify-content:space-between;
   margin-bottom:auto;
 }
+/* Right column: Authenticated pill stacked above contact channel icons */
+.hero__nav__right{
+  display:flex; flex-direction:column; align-items:flex-end; gap:10px;
+}
+.hero__channels{
+  display:flex; gap:8px;
+}
+.hero__channel{
+  width:34px; height:34px;
+  border-radius:50%;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:rgba(255,255,255,.04);
+  border:1px solid rgba(255,255,255,.14);
+  color:var(--periwinkle);
+  backdrop-filter:blur(10px);
+  -webkit-backdrop-filter:blur(10px);
+  transition: background .25s ease, border-color .25s ease,
+              color .25s ease, transform .25s ease;
+}
+.hero__channel:hover, .hero__channel:focus-visible{
+  background:rgba(255,255,255,.10);
+  border-color:rgba(255,255,255,.28);
+  color:#fff;
+  transform:translateY(-1px);
+}
+.hero__channel svg{ width:15px; height:15px; }
 .hero__brand{
   display:inline-flex; align-items:center; gap:10px;
   color:#fff;


### PR DESCRIPTION
Adds two glass-pill icon links to the hero top-right, stacked under the Authenticated pill. Instagram and email reachable without scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)