### PR TITLE
fix(renovaelabs): bump rotation speed ~70% on mobile (both versions)

### DIFF
--- a/public/renovaelabs-dark/app.js
+++ b/public/renovaelabs-dark/app.js
@@ -331,7 +331,9 @@
     // Together these recreate the "alive" feel the mouse-driven version
     // had without depending on a cursor.
     const tSec = (now - cam.t0) * 0.001;
-    cam.rotY += 0.0014;
+    // Faster spin on narrow viewports — same node count on a smaller area
+    // reads as slower motion per pixel, so mobile gets ~70% more.
+    cam.rotY += window.innerWidth < 760 ? 0.0024 : 0.0014;
     cam.rotX = -0.16 + Math.sin(tSec * 0.34) * 0.10 + cam.scrollT * 0.4;
     cam.cx = Math.cos(tSec * 0.18) * 26;
     cam.cy = Math.sin(tSec * 0.23) * 16;

--- a/public/renovaelabs/app.js
+++ b/public/renovaelabs/app.js
@@ -318,12 +318,10 @@
   function tick(now){
     if (!running){ raf = 0; return; }
 
-    // Camera evolution — fixed-speed rotation. Why: previous mouse-pull
-    // accelerated the spin proportional to cursor distance from centre,
-    // which on desktop made the network feel jittery and inconsistent
-    // versus mobile (where there's no mouse). Now constant base spin
-    // plus scroll-linked X tilt only.
-    cam.rotY += 0.0014;
+    // Camera evolution — fixed-speed rotation, faster on mobile.
+    // Why: same node count on a much smaller viewport reads as slower
+    // motion per pixel, so narrow screens get ~70% more spin.
+    cam.rotY += window.innerWidth < 760 ? 0.0024 : 0.0014;
     cam.rotX = cam.scrollT * 0.4;
 
     // Update nodes (motion in 3D box; wrap on each axis)


### PR DESCRIPTION
Mobile viewports get 0.0024 rad/frame vs 0.0014 on desktop. Network reads with the right energy on small screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)