### PR TITLE
fix(renovaelabs): align HPLC spec floor and soften unverifiable claims

### DIFF
--- a/public/renovaelabs-dark/index.html
+++ b/public/renovaelabs-dark/index.html
@@ -154,7 +154,7 @@
       <span class="eyebrow">§01 — Verification</span>
       <h2 class="display">A genuine, traceable unit.</h2>
       <p class="lead">
-        Every Renovae Labs product is sealed against a digitally signed manufacturing
+        Every Renovae Labs product is sealed against an internal manufacturing
         record. The QR you scanned cross-references that record now.
       </p>
     </header>
@@ -195,7 +195,7 @@
         </div>
         <div class="coa-row">
           <dt>Assay (HPLC)</dt>
-          <dd class="mono">≥ 99.0 %</dd>
+          <dd class="mono">≥ 98.0 %</dd>
         </div>
         <div class="coa-row">
           <dt>Mass-Spec Identity</dt>
@@ -297,7 +297,7 @@
       <li class="process__step reveal">
         <span class="process__num">02</span>
         <h3 class="process__title">Verification</h3>
-        <p>Independent third-party analytical testing on every batch:
+        <p>Independent third-party analytical testing on production batches:
           identity, purity, content, and contaminant screening.</p>
         <ul class="process__meta">
           <li>HPLC purity ≥ 98%</li>
@@ -310,11 +310,11 @@
         <span class="process__num">03</span>
         <h3 class="process__title">Sealed</h3>
         <p>Tamper-evident packaging, batch-coded label, and a unique QR
-          bound to the manufacturing record you're verifying right now.</p>
+          bound to the batch record this scan references.</p>
         <ul class="process__meta">
           <li>Tamper-evident seal</li>
           <li>Unique QR per unit</li>
-          <li>Signed digital record</li>
+          <li>Digital batch record</li>
         </ul>
       </li>
     </ol>
@@ -342,7 +342,7 @@
           </svg>
         </div>
         <h3>Independently tested</h3>
-        <p>Third-party laboratories analyse samples from every production batch before release.</p>
+        <p>Third-party laboratories analyse samples from production batches before release.</p>
       </article>
 
       <article class="trust__card reveal">
@@ -365,7 +365,7 @@
           </svg>
         </div>
         <h3>Batch traceability</h3>
-        <p>Each unit carries a unique identifier bound to the full manufacturing record.</p>
+        <p>Each unit carries a unique identifier bound to its batch record.</p>
       </article>
 
       <article class="trust__card reveal">
@@ -466,9 +466,9 @@
     <div class="about__grid reveal">
       <div class="about__col">
         <p>Renovae Labs exists for one reason: to deliver peptide systems of
-        uncompromising consistency. Every batch is engineered against tightly
-        defined specifications, then independently verified before it ever
-        leaves our facility.</p>
+        uncompromising consistency. Batches are engineered against tightly
+        defined specifications, then independently verified before they
+        leave our facility.</p>
       </div>
       <div class="about__col">
         <p>We don't market noise. We focus on purity, repeatability, and a

--- a/public/renovaelabs/index.html
+++ b/public/renovaelabs/index.html
@@ -154,7 +154,7 @@
       <span class="eyebrow">§01 — Verification</span>
       <h2 class="display">A genuine, traceable unit.</h2>
       <p class="lead">
-        Every Renovae Labs product is sealed against a digitally signed manufacturing
+        Every Renovae Labs product is sealed against an internal manufacturing
         record. The QR you scanned cross-references that record now.
       </p>
     </header>
@@ -195,7 +195,7 @@
         </div>
         <div class="coa-row">
           <dt>Assay (HPLC)</dt>
-          <dd class="mono">≥ 99.0 %</dd>
+          <dd class="mono">≥ 98.0 %</dd>
         </div>
         <div class="coa-row">
           <dt>Mass-Spec Identity</dt>
@@ -297,7 +297,7 @@
       <li class="process__step reveal">
         <span class="process__num">02</span>
         <h3 class="process__title">Verification</h3>
-        <p>Independent third-party analytical testing on every batch:
+        <p>Independent third-party analytical testing on production batches:
           identity, purity, content, and contaminant screening.</p>
         <ul class="process__meta">
           <li>HPLC purity ≥ 98%</li>
@@ -310,11 +310,11 @@
         <span class="process__num">03</span>
         <h3 class="process__title">Sealed</h3>
         <p>Tamper-evident packaging, batch-coded label, and a unique QR
-          bound to the manufacturing record you're verifying right now.</p>
+          bound to the batch record this scan references.</p>
         <ul class="process__meta">
           <li>Tamper-evident seal</li>
           <li>Unique QR per unit</li>
-          <li>Signed digital record</li>
+          <li>Digital batch record</li>
         </ul>
       </li>
     </ol>
@@ -342,7 +342,7 @@
           </svg>
         </div>
         <h3>Independently tested</h3>
-        <p>Third-party laboratories analyse samples from every production batch before release.</p>
+        <p>Third-party laboratories analyse samples from production batches before release.</p>
       </article>
 
       <article class="trust__card reveal">
@@ -365,7 +365,7 @@
           </svg>
         </div>
         <h3>Batch traceability</h3>
-        <p>Each unit carries a unique identifier bound to the full manufacturing record.</p>
+        <p>Each unit carries a unique identifier bound to its batch record.</p>
       </article>
 
       <article class="trust__card reveal">
@@ -466,9 +466,9 @@
     <div class="about__grid reveal">
       <div class="about__col">
         <p>Renovae Labs exists for one reason: to deliver peptide systems of
-        uncompromising consistency. Every batch is engineered against tightly
-        defined specifications, then independently verified before it ever
-        leaves our facility.</p>
+        uncompromising consistency. Batches are engineered against tightly
+        defined specifications, then independently verified before they
+        leave our facility.</p>
       </div>
       <div class="about__col">
         <p>We don't market noise. We focus on purity, repeatability, and a


### PR DESCRIPTION
## Summary
- Align COA card assay floor with the Specs strip (both now ≥ 98.0 %), removing the 99.0 % vs 98.0 % contradiction
- Soften unverifiable claims that lacked supporting downloads ("digitally signed manufacturing record", "every batch", "verifying right now", "full manufacturing record")
- Mirror identical edits to the dark variant so both routes stay in sync

## Test plan
- [ ] Visit `/renovaelabs/` — Verification card reads `≥ 98.0 %`, matching the Release Specifications strip below
- [ ] Verification copy: "sealed against an internal manufacturing record"
- [ ] Process step 02 reads "on production batches" (not "every batch")
- [ ] Process step 03 / Batch traceability tile reference "batch record" (not "full manufacturing record" / "verifying right now")
- [ ] Trust tile "Independently tested" reads "production batches" (not "every production batch")
- [ ] About paragraph: "Batches are engineered…" (not "Every batch…")
- [ ] `/renovaelabs-dark/` shows the same copy as `/renovaelabs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)