### PR TITLE
brand(renovaelabs): nav logo lockup + verify stamp font fix

### DIFF
--- a/public/renovaelabs/index.html
+++ b/public/renovaelabs/index.html
@@ -48,21 +48,13 @@
   <div class="hero__veil" aria-hidden="true"></div>
 
   <nav class="hero__nav" aria-label="Page navigation">
-    <a class="hero__brand" href="#top">
-      <span class="hero__brand__mark" aria-hidden="true">
-        <svg viewBox="0 0 32 32" width="22" height="22">
-          <circle cx="16" cy="16" r="2" fill="currentColor"/>
-          <circle cx="6"  cy="10" r="1.5" fill="currentColor"/>
-          <circle cx="26" cy="22" r="1.5" fill="currentColor"/>
-          <circle cx="22" cy="6"  r="1"   fill="currentColor"/>
-          <circle cx="10" cy="26" r="1"   fill="currentColor"/>
-          <line x1="16" y1="16" x2="6"  y2="10" stroke="currentColor" stroke-width=".6"/>
-          <line x1="16" y1="16" x2="26" y2="22" stroke="currentColor" stroke-width=".6"/>
-          <line x1="16" y1="16" x2="22" y2="6"  stroke="currentColor" stroke-width=".4"/>
-          <line x1="16" y1="16" x2="10" y2="26" stroke="currentColor" stroke-width=".4"/>
-        </svg>
+    <a class="hero__brand" href="#top" aria-label="Renovae Labs">
+      <span class="hero__brand__word">RENOVAE</span>
+      <span class="hero__brand__sub" aria-hidden="true">
+        <span class="hero__brand__rule"></span>
+        LABS
+        <span class="hero__brand__rule"></span>
       </span>
-      <span class="hero__brand__text">RENOVAE</span>
     </a>
     <div class="hero__nav__right">
       <span class="hero__pill" aria-hidden="true">

--- a/public/renovaelabs/styles.css
+++ b/public/renovaelabs/styles.css
@@ -438,15 +438,12 @@ a{ color:inherit; text-decoration:none; }
 @keyframes drawCheck{ to{ stroke-dashoffset:0; } }
 
 /* Two text states stacked — fade between them on the same timeline as
-   the spinner-out / check-in transition.
-   Why: width sized to fit "Authenticity" + status under GrandCentral/Source
-   Sans (wider metrics than the previous Inter+Cormorant pair); height bumped
-   so the larger status line clears its descenders without clipping. */
+   the spinner-out / check-in transition. */
 .verify-stamp__text{
   position:relative;
   display:block;
-  min-width:170px;
-  height:44px;
+  min-width:130px;
+  height:38px;
 }
 .verify-stamp__state{
   position:absolute;
@@ -481,14 +478,14 @@ a{ color:inherit; text-decoration:none; }
   color:var(--periwinkle);
 }
 .verify-stamp__status{
-  font-family:var(--f-display);
-  /* Why: GrandCentral runs slightly wider than Cormorant — drop a touch and
-     drop the bold weight so the line stays inside the pill. */
-  font-size:1.45rem;
-  font-weight:400;
-  line-height:1.05;
-  margin-top:3px;
-  letter-spacing:.005em;
+  /* Why: pinned to Cormorant Garamond (not the brand display var) — keeps the
+     italic-friendly proportions the stamp was designed against. GrandCentral
+     Bold reads too heavy here and overflows the pill. */
+  font-family:'Cormorant Garamond', 'Times New Roman', serif;
+  font-size:1.6rem;
+  font-weight:500;
+  line-height:1;
+  margin-top:2px;
 }
 
 /* Scroll cue */

--- a/public/renovaelabs/styles.css
+++ b/public/renovaelabs/styles.css
@@ -239,15 +239,36 @@ a{ color:inherit; text-decoration:none; }
   transform:translateY(-1px);
 }
 .hero__channel svg{ width:15px; height:15px; }
+/* Why: header logo is a miniature of the brand lockup — RENOVAE in
+   GrandCentral over a small "LABS" sub with flanking rules. Echoes the
+   wordmark below at nav scale and stays on-spec. */
 .hero__brand{
-  display:inline-flex; align-items:center; gap:10px;
+  display:inline-flex; flex-direction:column; align-items:flex-start; gap:4px;
   color:#fff;
-  font-family:var(--f-sans);
-  font-weight:500;
-  font-size:.78rem;
-  letter-spacing:.36em;
+  text-decoration:none;
+  line-height:1;
 }
-.hero__brand__mark{ color:var(--periwinkle); }
+.hero__brand__word{
+  font-family:var(--f-display);
+  font-weight:400;
+  font-size:.95rem;
+  letter-spacing:.34em;
+  text-indent:.34em;
+  color:#fff;
+}
+.hero__brand__sub{
+  display:inline-flex; align-items:center; gap:8px;
+  font-family:var(--f-display);
+  font-weight:400;
+  font-size:.55rem;
+  letter-spacing:.5em;
+  text-indent:.5em;
+  color:var(--periwinkle);
+}
+.hero__brand__rule{
+  height:1px; width:18px;
+  background:linear-gradient(90deg, transparent, var(--periwinkle), transparent);
+}
 .hero__pill{
   display:inline-flex; align-items:center; gap:8px;
   padding:8px 14px;
@@ -417,12 +438,15 @@ a{ color:inherit; text-decoration:none; }
 @keyframes drawCheck{ to{ stroke-dashoffset:0; } }
 
 /* Two text states stacked — fade between them on the same timeline as
-   the spinner-out / check-in transition. */
+   the spinner-out / check-in transition.
+   Why: width sized to fit "Authenticity" + status under GrandCentral/Source
+   Sans (wider metrics than the previous Inter+Cormorant pair); height bumped
+   so the larger status line clears its descenders without clipping. */
 .verify-stamp__text{
   position:relative;
   display:block;
-  min-width:130px;
-  height:38px;
+  min-width:170px;
+  height:44px;
 }
 .verify-stamp__state{
   position:absolute;
@@ -458,10 +482,13 @@ a{ color:inherit; text-decoration:none; }
 }
 .verify-stamp__status{
   font-family:var(--f-display);
-  font-size:1.6rem;
-  font-weight:500;
-  line-height:1;
-  margin-top:2px;
+  /* Why: GrandCentral runs slightly wider than Cormorant — drop a touch and
+     drop the bold weight so the line stays inside the pill. */
+  font-size:1.45rem;
+  font-weight:400;
+  line-height:1.05;
+  margin-top:3px;
+  letter-spacing:.005em;
 }
 
 /* Scroll cue */


### PR DESCRIPTION
## Summary
- Replace the molecular SVG mark in the nav with a miniature of the brand lockup (RENOVAE in GrandCentral over a small "LABS" sub with flanking rules) so the nav matches the spec wordmark below
- Pin the verify stamp status text to Cormorant Garamond directly (instead of inheriting the new GrandCentral display var) — GrandCentral Bold reads too heavy at 1.6rem and was overflowing the pill
- Restore the original `min-width` + `height` on the stamp text container now that Cormorant fits again

## Test plan
- [ ] Nav logo renders as RENOVAE / LABS lockup (no SVG mark)
- [ ] Verify stamp pill fully contains both states ("Verification / Checking…" and "Authenticity / Confirmed") in the original italic-friendly serif
