### PR TITLE
fix(tomthevacuumman): a11y — scroll-margin, contrast, focus

### DIFF
--- a/public/tomthevacuumman/index.html
+++ b/public/tomthevacuumman/index.html
@@ -186,7 +186,7 @@
 
 <!-- ====== MASTHEAD ====== -->
 <header class="masthead">
-  <a href="#top" class="masthead__mark" aria-label="Tom the Vacuum Man — home">
+  <a href="#top" class="masthead__mark">
     <span class="mark__line-1">Tom the</span>
     <span class="mark__line-2">Vacuum Man</span>
     <span class="mark__meta">Vacuum Cleaner Services · Leicester</span>

--- a/public/tomthevacuumman/script.js
+++ b/public/tomthevacuumman/script.js
@@ -49,6 +49,9 @@
   }
 
   // --- Smooth scroll for in-page anchors -------------------------------
+  // Why: focus the section's heading (not the section itself) so screen readers
+  // announce the destination context, not the bare landmark. Tabindex is set
+  // once on first activation to avoid mutating the DOM on every click.
   document.querySelectorAll('a[href^="#"]').forEach((a) => {
     a.addEventListener('click', (e) => {
       const id = a.getAttribute('href').slice(1);
@@ -60,9 +63,11 @@
         behavior: prefersReducedMotion ? 'auto' : 'smooth',
         block: 'start'
       });
-      // Move focus to the target for keyboard/screen-reader users
-      target.setAttribute('tabindex', '-1');
-      target.focus({ preventScroll: true });
+      const focusTarget = target.querySelector('h1, h2, h3') || target;
+      if (!focusTarget.hasAttribute('tabindex')) {
+        focusTarget.setAttribute('tabindex', '-1');
+      }
+      focusTarget.focus({ preventScroll: true });
     });
   });
 

--- a/public/tomthevacuumman/style.css
+++ b/public/tomthevacuumman/style.css
@@ -15,7 +15,7 @@
   --cream-deep:   #E2CFB0;
   --ink:          #1A1612;
   --ink-soft:     #3A3229;
-  --ink-quiet:    #6E6458;
+  --ink-quiet:    #5F5648;  /* Why: AA contrast on --cream-warm at 11px (was #6E6458 → 4.32:1, fails 1.4.3). 5F5648 → 5.35:1 on cream-warm, 5.92:1 on cream. */
   --brass:        #C9922B;
   --brass-deep:   #9B6E1D;
   --duck:         #9EB7B0;
@@ -45,7 +45,10 @@
 
 /* ---------- RESET ---------- */
 *, *::before, *::after { box-sizing: border-box; }
-html { -webkit-text-size-adjust: 100%; }
+html { -webkit-text-size-adjust: 100%; color-scheme: light; }
+/* Why: ribbon is position:sticky; without scroll-margin, anchor-jump targets land
+   under the ribbon (WCAG 2.2 SC 2.4.11 Focus Not Obscured). 72px ≈ ribbon height + breathing room. */
+:where(section[id], h1, h2, h3, [id]:target) { scroll-margin-top: 72px; }
 body, h1, h2, h3, h4, p, ul, ol, li, dl, dt, dd, figure, blockquote { margin: 0; padding: 0; }
 ul, ol { list-style: none; }
 img, svg { display: block; max-width: 100%; height: auto; }
@@ -57,9 +60,16 @@ input, textarea, select, button { font: inherit; color: inherit; }
 /* Visually hidden until focused — gives keyboard users a way to bypass the
    ribbon and masthead and jump straight to #top. */
 .skip-link {
+  /* Why: clip-path pattern (vs left:-9999px) avoids extending document scroll
+     width and works under RTL. */
   position: absolute;
-  left: -9999px;
-  top: 0;
+  top: 8px;
+  left: 8px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
   background: var(--ink);
   color: var(--cream);
   padding: 10px 16px;
@@ -71,8 +81,9 @@ input, textarea, select, button { font: inherit; color: inherit; }
   z-index: 1000;
 }
 .skip-link:focus {
-  left: 8px;
-  top: 8px;
+  width: auto;
+  height: auto;
+  clip-path: none;
   outline: 2px solid var(--brass);
   outline-offset: 2px;
 }
@@ -270,9 +281,12 @@ section {
 }
 .masthead__nav a:not(.nav__cta):hover::after { right: 0; }
 .nav__cta {
+  display: inline-flex;
+  align-items: center;
   background: var(--claret);
   color: var(--cream) !important;
   padding: 10px 16px;
+  min-height: 44px; /* Why: matches .btn touch-target floor (Apple HIG / WCAG 2.5.5 AAA). */
   border-radius: var(--r-2);
   letter-spacing: 0.16em;
   transition: background 180ms ease, transform 180ms ease;


### PR DESCRIPTION
## Summary

Two real WCAG 2.2 AA failures plus polish on the tom-the-vacuum-man demo build (public/tomthevacuumman/).

- **Sticky ribbon obscured anchor targets** (WCAG 2.4.11) — added scroll-margin-top: 72px on :where(section[id], h1, h2, h3, [id]:target).
- **--ink-quiet on --cream-warm failed AA at 11px** (WCAG 1.4.3) — was #6E6458 ≈ 4.32:1 on cream-warm. Darkened to #5F5648 (5.35:1 on cream-warm, 5.92:1 on cream).
- Skip link migrated from left: -9999px to clip-path: inset(50%) — RTL-safe and doesn't extend document scroll width.
- .nav__cta got min-height: 44px + display: inline-flex to match .btn touch-target.
- Smooth-scroll handler now focuses the section's heading instead of the section element, and only sets tabindex once.
- Dropped redundant aria-label on masthead mark so the mono meta line is exposed to AT.
- Added color-scheme: light on html.

## Test plan

- [ ] Click each in-page nav link (story / mobile / trade / tiktok / contact) — section heading visible below the ribbon, not under it.
- [ ] Tab to skip link from page load — appears top-left and activates main content.
- [ ] DevTools contrast picker on docket labels, stat labels, receipt subtitle — all over 4.5:1.
- [ ] VoiceOver: masthead mark announces "Tom the · Vacuum Man · Vacuum Cleaner Services · Leicester".
